### PR TITLE
[feat] add outcome explanation

### DIFF
--- a/collections/2025/crystal_2025.ml
+++ b/collections/2025/crystal_2025.ml
@@ -32,7 +32,7 @@ let all =
         ~precise:
           "The winner of the 2025 US Open Men's Singles Final is under 25 years old on \
            the day of the final match, as determined by official ATP birthdate records."
-        ~outcome:Yes
+        ~outcome:(Yes (Explanation.create ~date:(Date.of_string "2025-09-07") ~description:"Carlos Alcaraz (Born May 5, 2003, Age 22) defeated Jannik Sinner 6-2 3-6 6-1 6-4 to win the 2025 US Open Men's Singles tournament" ~link:"https://www.instagram.com/p/DOUPJaRiXFD/" ()))
     ; Event.create
         ~short:"Sam Bankman-Fried is pardoned"
         ~precise:
@@ -58,7 +58,7 @@ let all =
         ~precise:
           "Travis Kelce and Taylor Swift are reported to be engaged on or before \
            2025-12-31, via a consensus of credible media reporting or primary sources."
-        ~outcome:Yes
+        ~outcome:(Yes (Explanation.create ~date:(Date.of_string "2025-08-26") ~description:"Travis Kelce and Taylor Swift were engaged on August 26th, 2025 as confirmed on instgram." ~link:"https://www.instagram.com/p/DN02niAXMM-/" ()))
     ; Event.create
         ~short:"Life is discovered beyond Earth"
         ~precise:
@@ -115,7 +115,7 @@ let all =
         ~precise:
           "At least one world record is broken at the 2025 World Athletics Championships \
            in Tokyo, confirmed by World Athletics."
-        ~outcome:Yes
+        ~outcome:(Yes (Explanation.create ~date:(Date.of_string "2025-09-15") ~description:"Armand \"Mondo\" Duplantis broke the men's pole vault record by clearing a height of 20 ft, 8 inches" ~link:"https://www.espn.com/olympics/trackandfield/story/_/id/46269417/armand-duplantis-breaks-pole-vault-world-record-14th" ()))
     ; Event.create
         ~short:"More than three participants change employment status"
         ~precise:

--- a/crystal-ball-cup.opam
+++ b/crystal-ball-cup.opam
@@ -26,6 +26,8 @@ depends: [
   "js_of_ocaml-compiler"
   "promise_jsoo"
   "metaquot"
+  "yojson"
+  "ppx_deriving_yojson"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/event.ml
+++ b/src/event.ml
@@ -10,3 +10,18 @@ type t =
 
 let create = Fields.create
 let score t ~probability = Outcome.score t.outcome ~probability
+
+let compare_by_outcome_date t1 t2 =
+  (* For equality, compare event id *)
+  let id_cmp = Event_id.compare t1.id t2.id in
+  if id_cmp = 0 then 0
+  else
+    match t1.outcome, t2.outcome with
+    (* If both are pending, sort alphabetically by short text *)
+    | Pending, Pending -> String.compare t1.short t2.short
+    (* If one is pending and other is resolved, pending goes last *)
+    | Pending, (Yes _ | No _) -> 1
+    | (Yes _ | No _), Pending -> -1
+    (* If both are resolved, sort by outcome date *)
+    | (Yes exp1 | No exp1), (Yes exp2 | No exp2) ->
+      Date.compare (Explanation.date exp1) (Explanation.date exp2)

--- a/src/event.mli
+++ b/src/event.mli
@@ -8,3 +8,4 @@ val short : t -> string
 val precise : t -> string
 val outcome : t -> Outcome.t
 val score : t -> probability:float -> float
+val compare_by_outcome_date : t -> t -> int

--- a/src/explanation.ml
+++ b/src/explanation.ml
@@ -1,0 +1,7 @@
+open! Core
+
+type t = { date : Date.t; description : string; link : string option; } 
+[@@deriving compare, equal, sexp, fields]
+
+let create ~date ~description ?link () =
+  { date; description; link }

--- a/src/explanation.mli
+++ b/src/explanation.mli
@@ -1,0 +1,10 @@
+open! Core
+
+type t = { date : Date.t; description : string; link : string option; } 
+
+[@@deriving compare, equal, sexp]
+
+val create : date:Date.t -> description:string -> ?link:string -> unit -> t
+val link : t -> string option
+val date : t -> Date.t
+val description : t -> string

--- a/src/outcome.ml
+++ b/src/outcome.ml
@@ -3,33 +3,42 @@ open! Core
 module T = struct
   type t =
     | Pending
-    | Yes
-    | No
-  [@@deriving compare, equal, sexp, enumerate]
+    | Yes of Explanation.t
+    | No of Explanation.t
+  [@@deriving compare, equal, sexp]
 end
 
 include T
 include Comparable.Make (T)
 
-let to_string = function
-  | Pending -> "Pending"
-  | Yes -> "Yes"
-  | No -> "No"
-;;
-
-let of_string = function
-  | "Pending" -> Ok Pending
-  | "Yes" -> Ok Yes
-  | "No" -> Ok No
-  | s -> Error [%string "unknown outcome %{s}"]
-;;
-
 let score t ~probability =
   let ln = Float.log in
   match t with
   | Pending -> Float.nan
-  | Yes -> ln probability -. ln 0.5
-  | No -> ln (1.0 -. probability) -. ln 0.5
+  | Yes _ -> ln probability -. ln 0.5
+  | No _ -> ln (1.0 -. probability) -. ln 0.5
 ;;
 
-let caqti_type = Caqti_type.enum "Outcome.t" ~encode:to_string ~decode:of_string
+let to_kind = function
+  | Pending -> Outcome_kind.Pending
+  | Yes _ -> Outcome_kind.Yes
+  | No _ -> Outcome_kind.No
+;;
+
+let to_string t = Outcome_kind.to_string (to_kind t)
+
+let caqti_type =
+  let encode t =
+    try
+      let sexp = sexp_of_t t in
+      Ok (Sexp.to_string sexp)
+    with exn -> Error ("Failed to encode outcome: " ^ Exn.to_string exn)
+  in
+  let decode sexp_str =
+    try
+      let sexp = Sexp.of_string sexp_str in
+      let outcome = t_of_sexp sexp in
+      Ok outcome
+    with exn -> Error ("Failed to parse outcome: " ^ Exn.to_string exn)
+  in
+  Caqti_type.custom ~encode ~decode Caqti_type.string

--- a/src/outcome.mli
+++ b/src/outcome.mli
@@ -2,12 +2,14 @@ open! Core
 
 type t =
   | Pending
-  | Yes
-  | No
-[@@deriving compare, equal, sexp, enumerate]
+  | Yes of Explanation.t
+  | No of Explanation.t
+[@@deriving compare, equal, sexp]
 
 include Comparable.S with type t := t
 
 val caqti_type : t Caqti_type.t
-val to_string : t -> string
 val score : t -> probability:float -> float
+
+val to_kind : t -> Outcome_kind.t
+val to_string : t -> string

--- a/src/outcome_kind.ml
+++ b/src/outcome_kind.ml
@@ -1,0 +1,17 @@
+open! Core
+
+module T = struct
+  type t =
+    | Pending
+    | Yes
+    | No
+  [@@deriving compare, equal, sexp, enumerate]
+end
+
+include T
+include Comparable.Make (T)
+let to_string = function
+  | Pending -> "Pending"
+  | Yes -> "Yes"
+  | No -> "No"
+;;

--- a/src/outcome_kind.mli
+++ b/src/outcome_kind.mli
@@ -1,0 +1,12 @@
+open! Core
+
+type t =
+  | Pending
+  | Yes
+  | No
+[@@deriving compare, equal, sexp, enumerate]
+
+include Comparable.S with type t := t
+
+val to_string : t -> string
+

--- a/test/test_collection.ml
+++ b/test/test_collection.ml
@@ -13,12 +13,12 @@ let all =
       ~id:(Event_id.of_int 2)
       ~short:"Event2"
       ~precise:"Precise description for event 2"
-      ~outcome:Yes
+      ~outcome:(Yes (Explanation.create ~date:(Date.of_string "2025-01-01") ~description:"Description proving event 2" ~link:"https://www.link.that/proves/event/2" ()))
   ; Event.create
       ~id:(Event_id.of_int 3)
       ~short:"Event3"
       ~precise:"Precise description for event 3"
-      ~outcome:No
+      ~outcome:(No (Explanation.create ~date:(Date.of_string "2025-12-31") ~description:"Description that describes why event 3 didnt happen" ()))
   ]
 ;;
 

--- a/test/test_outcome.ml
+++ b/test/test_outcome.ml
@@ -2,7 +2,7 @@ open! Core
 open Crystal
 
 let%expect_test "score" =
-  let outcomes : Outcome.t list = [ Pending; Yes; No ] in
+  let outcomes : Outcome.t list = [ Pending; Yes (Explanation.create ~date:(Date.of_string "2025-01-01") ~description:"Description of why yes" ~link:"https://www.link.why/yes" ()); No (Explanation.create ~date:(Date.of_string "2025-12-31") ~description:"Description that describes why not" ()) ] in
   let probabilities = [ 0.0; 0.1; 0.5; 0.9; 1.0 ] in
   let rows =
     List.cartesian_product outcomes probabilities


### PR DESCRIPTION
- add new type for outcome explanation
- Add the information in detail view
- Add the information on multi view as well

A follow up PR should aim to merge the renderPlots logic with the text logic because at the moment there's no reason for them to be disconnected.
